### PR TITLE
Support for SSD1306 in I2C

### DIFF
--- a/board-package-source/boards.txt
+++ b/board-package-source/boards.txt
@@ -147,6 +147,12 @@ arduboy-homemade.menu.display.ssd1306.usb_product_postfix=1306
 arduboy-homemade.menu.display.ssd1306.bootloader_display=
 arduboy-homemade.menu.display.ssd1306.build.extra_flags=-DARDUBOY_10 -DOLED_SSD1306 {build.flash_cs} {build.usb_flags}
 
+arduboy-homemade.menu.display.ssd1306i2c=SSD1306 I2C
+arduboy-homemade.menu.display.ssd1306i2c.build.display=-ssd1306i2c
+arduboy-homemade.menu.display.ssd1306i2c.usb_product_postfix=1306i2c
+arduboy-homemade.menu.display.ssd1306i2c.bootloader_display=
+arduboy-homemade.menu.display.ssd1306i2c.build.extra_flags=-DARDUBOY_10 -DOLED_SSD1306_I2C {build.flash_cs} {build.usb_flags}
+
 arduboy-homemade.menu.display.ssd1309=SSD1309
 arduboy-homemade.menu.display.ssd1309.build.display=-ssd1309
 arduboy-homemade.menu.display.ssd1309.usb_product_postfix=1309

--- a/board-package-source/libraries/Arduboy2/src/Sprites.cpp
+++ b/board-package-source/libraries/Arduboy2/src/Sprites.cpp
@@ -44,24 +44,27 @@ void Sprites::draw(int16_t x, int16_t y,
   if (bitmap == NULL)
     return;
 
-//  uint8_t width = pgm_read_byte(bitmap);
-//  uint8_t height = pgm_read_byte(++bitmap);
-//  bitmap++;
-//  if (frame > 0 || sprite_frame > 0) {
-//    frame_offset = (width * ( height / 8 + ( height % 8 == 0 ? 0 : 1)));
-//    // sprite plus mask uses twice as much space for each frame
-//    if (drawMode == SPRITE_PLUS_MASK) {
-//      frame_offset *= 2;
-//    } else if (mask != NULL) {
-//      mask += sprite_frame * frame_offset;
-//    }
-//    bitmap += frame * frame_offset;
-//  }
-//  // if we're detecting the draw mode then base it on whether a mask
-//  // was passed as a separate object
-//  if (drawMode == SPRITE_AUTO_MODE) {
-//    drawMode = mask == NULL ? SPRITE_UNMASKED : SPRITE_MASKED;
-//  }
+#ifdef OLED_SSD1306_I2C
+  uint8_t width = pgm_read_byte(bitmap);
+  uint8_t height = pgm_read_byte(++bitmap);
+  bitmap++;
+  if (frame > 0 || sprite_frame > 0) {
+    frame_offset = (width * ( height / 8 + ( height % 8 == 0 ? 0 : 1)));
+    // sprite plus mask uses twice as much space for each frame
+    if (drawMode == SPRITE_PLUS_MASK) {
+      frame_offset *= 2;
+    } else if (mask != NULL) {
+      mask += sprite_frame * frame_offset;
+    }
+    bitmap += frame * frame_offset;
+  }
+
+  // if we're detecting the draw mode then base it on whether a mask
+  // was passed as a separate object
+  if (drawMode == SPRITE_AUTO_MODE) {
+    drawMode = mask == NULL ? SPRITE_UNMASKED : SPRITE_MASKED;
+  }
+#else 
   // assembly optimisation of above code saving 20(+) bytes
   uint8_t width;
   uint8_t height;
@@ -121,6 +124,9 @@ void Sprites::draw(int16_t x, int16_t y,
       [sprite_masked]    "M" (SPRITE_MASKED)
     : "r20", "r21"
   );
+
+#endif
+
   drawBitmap(x, y, bitmap, mask, width, height, drawMode);
 }
 


### PR DESCRIPTION
I grabbed some code from another fork and tried to integrate only the I2C SSD1306 display, it's working great for a bunch of games I'm compiling.

I was wondering if you wanted to take a look, see if it's worth adding ?

Would you like to integrate this ?

Original additional code for i2c found here - https://github.com/harbaum/Arduboy2

You just hook up the SSD1306 to the i2c pins on your boards
Which was 2 and 3 on my Sparkfun Pro Micro, ground and VCC